### PR TITLE
Changes leaflet import for esm version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,10 @@ cache:
   directories:
     - node_modules
 addons:
-  chrome: stable
+  apt:
+    packages:
+      - xvfb
+install:
+  - export DISPLAY=':99.0'
+  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+  - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.12"
+  - "6"
+  - "8"
 cache:
   directories:
     - node_modules
+addons:
+  chrome: stable

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "jsnext:main": "src/virtual-grid.js",
   "scripts": {
     "lint": "semistandard --verbose | snazzy",
-    "test": "npm run lint && browserify test/virtual-grid.js -t [ babelify --presets es2015 ] | tape-run --browser chrome | faucet",
+    "test": "npm run lint && browserify test/virtual-grid.js -t [ babelify --presets es2015 ] | tape-run | faucet",
     "bundle": "rollup src/virtual-grid.js -m dist/virtual-grid.js.map -e leaflet -f umd -o dist/virtual-grid.js -n VirtualGrid",
     "release": "scripts/release.sh",
     "prepublish": "npm run bundle"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "jsnext:main": "src/virtual-grid.js",
   "scripts": {
     "lint": "semistandard --verbose | snazzy",
-    "test": "npm run lint && browserify test/virtual-grid.js -t [ babelify --presets es2015 ] | tape-run --browser phantom | faucet",
+    "test": "npm run lint && browserify test/virtual-grid.js -t [ babelify --presets es2015 ] | tape-run --browser chrome | faucet",
     "bundle": "rollup src/virtual-grid.js -m dist/virtual-grid.js.map -e leaflet -f umd -o dist/virtual-grid.js -n VirtualGrid",
     "release": "scripts/release.sh",
     "prepublish": "npm run bundle"
@@ -37,7 +37,6 @@
     "faucet": "0.0.1",
     "gh-release": "^2.0.2",
     "isparta": "^4.0.0",
-    "phantomjs": "^2.1.7",
     "rollup": "^0.21.0",
     "semistandard": "^7.0.2",
     "sinon": "^1.17.2",
@@ -47,6 +46,6 @@
     "tape-run": "^2.1.0"
   },
   "dependencies": {
-    "leaflet": "^1.0.0-rc.1"
+    "leaflet": "^1.0.0"
   }
 }

--- a/src/virtual-grid.js
+++ b/src/virtual-grid.js
@@ -1,6 +1,13 @@
-import L from 'leaflet';
+import {
+  bounds as Lbounds,
+  latLngBounds as LlatLngBounds,
+  point as Lpoint,
+  Layer,
+  setOptions,
+  Util
+} from 'leaflet';
 
-var VirtualGrid = L.Layer.extend({
+var VirtualGrid = Layer.extend({
 
   options: {
     cellSize: 512,
@@ -8,13 +15,13 @@ var VirtualGrid = L.Layer.extend({
   },
 
   initialize: function (options) {
-    options = L.setOptions(this, options);
+    options = setOptions(this, options);
     this._zooming = false;
   },
 
   onAdd: function (map) {
     this._map = map;
-    this._update = L.Util.throttle(this._update, this.options.updateInterval, this);
+    this._update = Util.throttle(this._update, this.options.updateInterval, this);
     this._reset();
     this._update();
   },
@@ -97,7 +104,7 @@ var VirtualGrid = L.Layer.extend({
     var cellSize = this._getCellSize();
 
     // cell coordinates range for the current view
-    var cellBounds = L.bounds(
+    var cellBounds = Lbounds(
       bounds.min.divideBy(cellSize).floor(),
       bounds.max.divideBy(cellSize).floor());
 
@@ -116,7 +123,7 @@ var VirtualGrid = L.Layer.extend({
     // create a queue of coordinates to load cells from
     for (j = bounds.min.y; j <= bounds.max.y; j++) {
       for (i = bounds.min.x; i <= bounds.max.x; i++) {
-        coords = L.point(i, j);
+        coords = Lpoint(i, j);
         coords.z = zoom;
 
         if (this._isValidCell(coords)) {
@@ -162,7 +169,7 @@ var VirtualGrid = L.Layer.extend({
 
     // don't load cell if it doesn't intersect the bounds in options
     var cellBounds = this._cellCoordsToBounds(coords);
-    return L.latLngBounds(this.options.bounds).intersects(cellBounds);
+    return LlatLngBounds(this.options.bounds).intersects(cellBounds);
   },
 
   // converts cell coordinates to its geographical bounds
@@ -174,7 +181,7 @@ var VirtualGrid = L.Layer.extend({
     var nw = map.wrapLatLng(map.unproject(nwPoint, coords.z));
     var se = map.wrapLatLng(map.unproject(sePoint, coords.z));
 
-    return L.latLngBounds(nw, se);
+    return LlatLngBounds(nw, se);
   },
 
   // converts cell coordinates to key for the cell cache
@@ -188,7 +195,7 @@ var VirtualGrid = L.Layer.extend({
     var x = parseInt(kArr[0], 10);
     var y = parseInt(kArr[1], 10);
 
-    return L.point(x, y);
+    return Lpoint(x, y);
   },
 
   // remove any present cells that are off the specified bounds
@@ -279,8 +286,8 @@ var VirtualGrid = L.Layer.extend({
   },
 
   _wrapCoords: function (coords) {
-    coords.x = this._wrapLng ? L.Util.wrapNum(coords.x, this._wrapLng) : coords.x;
-    coords.y = this._wrapLat ? L.Util.wrapNum(coords.y, this._wrapLat) : coords.y;
+    coords.x = this._wrapLng ? Util.wrapNum(coords.x, this._wrapLng) : coords.x;
+    coords.y = this._wrapLat ? Util.wrapNum(coords.y, this._wrapLat) : coords.y;
   },
 
   // get the global cell coordinates range for the current zoom
@@ -288,7 +295,7 @@ var VirtualGrid = L.Layer.extend({
     var bounds = this._map.getPixelWorldBounds();
     var size = this._getCellSize();
 
-    return bounds ? L.bounds(
+    return bounds ? Lbounds(
         bounds.min.divideBy(size).floor(),
         bounds.max.divideBy(size).ceil().subtract([1, 1])) : null;
   }

--- a/test/virtual-grid.js
+++ b/test/virtual-grid.js
@@ -1,7 +1,7 @@
 import VirtualGrid from '../src/virtual-grid.js';
 import test from 'tape-catch';
 import sinon from 'sinon';
-import L from 'leaflet';
+import { map, point } from 'leaflet';
 
 function createMap () {
   // create container
@@ -13,7 +13,7 @@ function createMap () {
   // add contianer to body
   document.body.appendChild(container);
 
-  return L.map(container);
+  return map(container);
 }
 
 function createMockGrid () {
@@ -38,7 +38,7 @@ test('should create cells based on the view of the map', function (t) {
   var grid = createMockGrid();
 
   grid.on('cellsupdated', function () {
-    t.ok(grid.createCell.getCall(0).args[1].equals(L.point([0, 0])));
+    t.ok(grid.createCell.getCall(0).args[1].equals(point([0, 0])));
     map.remove();
   });
 
@@ -54,12 +54,12 @@ test('should create cells when the map zooms in', function (t) {
   grid.addTo(map);
 
   grid.on('cellsupdated', function () {
-    t.ok(grid.cellLeave.getCall(0).args[1].equals(L.point([0, 0, 1])));
+    t.ok(grid.cellLeave.getCall(0).args[1].equals(point([0, 0, 1])));
 
-    t.ok(grid.createCell.getCall(1).args[1].equals(L.point([0, 0, 2])));
-    t.ok(grid.createCell.getCall(2).args[1].equals(L.point([1, 0, 2])));
-    t.ok(grid.createCell.getCall(3).args[1].equals(L.point([0, 1, 2])));
-    t.ok(grid.createCell.getCall(4).args[1].equals(L.point([1, 1, 2])));
+    t.ok(grid.createCell.getCall(1).args[1].equals(point([0, 0, 2])));
+    t.ok(grid.createCell.getCall(2).args[1].equals(point([1, 0, 2])));
+    t.ok(grid.createCell.getCall(3).args[1].equals(point([0, 1, 2])));
+    t.ok(grid.createCell.getCall(4).args[1].equals(point([1, 1, 2])));
 
     map.remove();
   });
@@ -76,8 +76,8 @@ test('should create cells when the map is panned', function (t) {
   grid.addTo(map);
 
   grid.on('cellsupdated', function () {
-    t.ok(grid.createCell.getCall(4).args[1].equals(L.point([5, 4, 4])));
-    t.ok(grid.createCell.getCall(5).args[1].equals(L.point([4, 5, 4])));
+    t.ok(grid.createCell.getCall(4).args[1].equals(point([5, 4, 4])));
+    t.ok(grid.createCell.getCall(5).args[1].equals(point([4, 5, 4])));
     map.remove();
   });
 


### PR DESCRIPTION
On Leaflet’s master branch they’ve added a "module" entry that points to
a modulized version of Leaflet. Since that module has no default export,
this package needs to change to import from 'leaflet'.

Changed to import just pieces to be supportive of tree-shaking rather
than pulling in all of Leaflet.